### PR TITLE
Optimized where clause for search cursor at step 6.5

### DIFF
--- a/scripts/OSM_Loader.py
+++ b/scripts/OSM_Loader.py
@@ -608,11 +608,9 @@ for rel in unbuiltrelations:
         shape.removeAll()
         relid=areawayitems[0]
         members=areawayitems[1].split(':')
-        queryexpression=""""way_id" in ("""
         expecteditems=len(members)
-        for member in members:
-            queryexpression=queryexpression+"'"+str(member)+"',"
-        queryexpression=queryexpression.rstrip(',')+')'
+        querylist = '\',\''.join(members)
+        queryexpression = '"way_id" in (\'{0}\')'.format(querylist)
         actualitems=0
         for row in arcpy.da.SearchCursor(areawayfc,("way_id","SHAPE@"),queryexpression):
             for part in row[1]:


### PR DESCRIPTION
Used the join function instead of multiple self-concatenations in order to build the where clause passed to the search cursor in step 6.5. This is much more efficient since strings are immutable. This also makes the code more readable and less verbose. Tested on Luxembourg, it makes step 6.5 processing time go from 25 seconds to 17 seconds.