### PR TITLE
Added a check to prevent null geometries.

### DIFF
--- a/scripts/OSM_Loader.py
+++ b/scripts/OSM_Loader.py
@@ -615,9 +615,12 @@ for rel in unbuiltrelations:
         queryexpression=queryexpression.rstrip(',')+')'
         actualitems=0
         for row in arcpy.da.SearchCursor(areawayfc,("way_id","SHAPE@"),queryexpression):
-            for part in row[1]:
-                shape.add(part)
-            actualitems+=1
+            if row[1] is not None:
+                for part in row[1]:
+                    shape.add(part)
+                actualitems+=1
+            else:
+                arcpy.AddWarning('Geometry for way_id {0} is null'.format(row[0]))
         if actualitems==expecteditems:
             inShape=arcpy.Polygon(shape,SR)
             newrow=(relid,inShape)
@@ -632,9 +635,6 @@ unbuiltrelations.close()
 del areawaycursor
 arcpy.AddMessage("Complete multiAreas="+str(completerels))
 arcpy.AddMessage("Step 6.5 --- %s seconds ---" % (time.time() - stepstarttime))
-
-
-
 
 
 #Step 7 join Attributes to ways


### PR DESCRIPTION
Some null geometries seem to be generated. They appear at step 6.5 even though the content read by the search cursor is actually populated at step 5. My take is that the if a geometry is smaller then the feature class tolerance or resolution a null geometry replaces the geometry written in step 5, and is read at step 6.5. The code change allows the code to display a warning with the problematic way_id at step 6.5 and keep working instead of terminating with an error.